### PR TITLE
Upgrade repos are enabled by default

### DIFF
--- a/redhat_upgrade_tool/download.py
+++ b/redhat_upgrade_tool/download.py
@@ -225,7 +225,7 @@ class UpgradeDownloader(yum.YumBase):
                 with open(repofile, 'w') as f:
                     f.write("[redhat-upgrade-%s]\n" % repo.id)
                     f.write("name=Upgrade - %s\n" % repo.id)
-                    f.write("enabled=0\n")
+                    f.write("enabled=1\n")
                     f.write("skip_if_unavailable=True\n")
                     if repo.mirrorlist:
                         f.write("mirrorlist=%s\n" % repo.mirrorlist)


### PR DESCRIPTION
I think that if we create an upgrade repo then it should be enabled by default.
Am I right?
