### PR TITLE
Check for sufficient space in /boot

### DIFF
--- a/redhat_upgrade_tool/__init__.py
+++ b/redhat_upgrade_tool/__init__.py
@@ -68,3 +68,5 @@ preupgrade_dir = "/root/preupgrade"
 preupgrade_script_path = os.path.join(preupgrade_dir, 'preupgrade-scripts')
 release_version_file = os.path.join(preupgrade_dir, preupgrade_script_path, 'release_version')
 grub_conf_file = "/boot/grub/grub.conf"
+
+MIN_AVAIL_BYTES_FOR_BOOT = 50 * 2**20  # 50 MiB

--- a/redhat_upgrade_tool/download.py
+++ b/redhat_upgrade_tool/download.py
@@ -454,7 +454,11 @@ class UpgradeDownloader(yum.YumBase):
             cacheinitrd = os.path.join(cachedir, os.path.basename(initrdpath))
             initrd = grab_and_check(arch, 'upgrade', cacheinitrd)
             # copy the downloaded initrd to the target path
-            copy2(initrd, initrdpath)
+            try:
+                copy2(initrd, initrdpath)
+            except IOError as e:
+                print _("Copying initrd to '%s' failed:\n%s") % (initrdpath, e)
+                raise SystemExit(1)
             initrd = initrdpath
         except TreeinfoError as e:
             raise YumBaseError(_("invalid data in .treeinfo: %s") % str(e))


### PR DESCRIPTION
Installation of kernel and grub during the upgrade requires certain amount of space in /boot. If that space is not available during the upgrade stage after the reboot, the upgrade fails.
This update adds a check of the available space left after the initramfs and kernel are downloaded. 50 MB should be enough even with reserve.

Related:
  - RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1361219
  - Issue https://github.com/upgrades-migrations/redhat-upgrade-tool/issues/17