### PR TITLE
Add MANIFEST.in file for sdist to work properly (RHEL 7)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include   Makefile
+include   README.asciidoc
+include   COPYING
+
+include   man/*
+include   systemd/*

--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -44,7 +44,7 @@ mkdir -p $RPM_BUILD_ROOT/etc/redhat-upgrade-tool/update.img.d
 
 
 %files
-%doc README.asciidoc TODO.asciidoc COPYING
+%doc README.asciidoc COPYING
 # systemd stuff
 %{_unitdir}/system-upgrade.target
 %{_unitdir}/upgrade-prep.service


### PR DESCRIPTION
- running 'python setup.py sdist' did not pack all the files needed for the rpm package build
- also remove TODO list from spec - no need to pack it in an rpm