### PR TITLE
Add MANIFEST.in file for sdist to work properly (RHEL 6)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include   Makefile
+include   README.asciidoc
+include   COPYING
+
+include   man/*
+include   systemd/*
+

--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -43,7 +43,7 @@ mkdir -p $RPM_BUILD_ROOT/etc/redhat-upgrade-tool/update.img.d
 
 
 %files
-%doc README.asciidoc TODO.asciidoc COPYING
+%doc README.asciidoc COPYING
 # systemd stuff
 %if 0%{?_unitdir:1}
 %{_unitdir}/system-upgrade.target


### PR DESCRIPTION
- running 'python setup.py sdist' did not pack all the files needed for the rpm package build
- also remove TODO list from spec - no need to pack it in an rpm

Note: This is a copy of RHEL7 PR https://github.com/upgrades-migrations/redhat-upgrade-tool/pull/20 to RHEL6 branch.