### PR TITLE
Treeinfo file renamed product section (RHEL 6)

### DIFF
--- a/redhat-upgrade-tool.py
+++ b/redhat-upgrade-tool.py
@@ -252,7 +252,10 @@ def main(args):
     elif not f.instrepo.gpgcheck:
         # If instrepo is a Red Hat repo, add the gpg key and reload the repos
         try:
-            if f.treeinfo.get('product', 'name') == 'Red Hat Enterprise Linux':
+            key = "product"
+            if not f.treeinfo.has_section(key):
+                key = "release"
+            if f.treeinfo.get(key, 'name') == 'Red Hat Enterprise Linux':
                 log.info("Reloading repos with GPG key")
                 args.repos.append(('gpgkey', '%s=%s' % (f.instrepo.name, rhel_gpgkey_path)))
                 f = setup_downloader(version=args.network,


### PR DESCRIPTION
Format of the .treeinfo file has been changed in RHEL 7.4 repositories. RHEL repositories prior to 7.4 version had .treeinfo containing 'product' section which was not according to the specification [1]. To correct that, it was changed to 'release' section. Hence, redhat-upgrade-tool has been updated to allow both sections, 'product' as a default and 'release' as a fallback (thanks Marian Ganisin for the patch).

Related: RHBZ#[1456809](https://bugzilla.redhat.com/show_bug.cgi?id=1456809)

[1] http://productmd.readthedocs.io/en/latest/treeinfo-1.1.html

Note: This is a copy of RHEL7 PR #21 to RHEL6 branch.