### PR TITLE
Stop executing when .treeinfo not available

### DIFF
--- a/redhat_upgrade_tool/download.py
+++ b/redhat_upgrade_tool/download.py
@@ -406,7 +406,8 @@ class UpgradeDownloader(yum.YumBase):
                 log.debug("using cached .treeinfo %s", outfile)
                 self._treeinfo = Treeinfo(outfile)
             else:
-                log.debug("fetching .treeinfo from repo '%s'", self.instrepoid)
+                log.debug("fetching .treeinfo from repo '%s'",
+                          self.instrepo.urls[0])
                 if os.path.exists(outfile):
                     os.remove(outfile)
                 try:
@@ -418,8 +419,9 @@ class UpgradeDownloader(yum.YumBase):
                                                         reget=None)
                     except Exception as e:
                         log.error("Error downloading .treeinfo or treeinfo"
-                                  "from repo %s: %s" % (self.instrepoid, e))
-                        fn = None
+                                  " from repo %s: %s"
+                                  % (self.instrepo.urls[0], e))
+                        raise SystemExit(1)
                 self._treeinfo = Treeinfo(fn)
                 log.debug(".treeinfo saved at %s", fn)
             self._treeinfo.checkvalues()


### PR DESCRIPTION
When _.treeinfo_ or _treeinfo_ was not available, the Red Hat Upgrade Tool ended later on with an unrelated error, for example:
```
redhat_upgrade_tool.yum ERROR: Error downloading .treeinfo or treeinfofrom repo cmdline-instrepo: [Errno 14] PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"
Traceback (most recent call last):
  File "/usr/bin/redhat-upgrade-tool", line 448, in <module>
    main(args)
  File "/usr/bin/redhat-upgrade-tool", line 164, in main
    if f.treeinfo.get('general', 'version').split('.')[0] != \
  File "/usr/lib/python2.6/site-packages/redhat_upgrade_tool/download.py", line 425, in treeinfo
    self._treeinfo.checkvalues()
  File "/usr/lib/python2.6/site-packages/redhat_upgrade_tool/treeinfo.py", line 186, in checkvalues
    self.get('general', f)
  File "/usr/lib64/python2.6/ConfigParser.py", line 321, in get
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'general'
```
Now the utility stops it's execution right away and the error message specifies the repository URL, not just its internal ID (_cmdline-instrepo_):
```
redhat_upgrade_tool.yum ERROR: Error downloading .treeinfo or treeinfo from repo http://download.eng.brq.redhat.com/scratch/mbocek/dotless_treeinfo_repo/: [Errno 14] PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"
```

This fix was inspired by [rhbz#1486439](https://bugzilla.redhat.com/show_bug.cgi?id=1486439).