### PR TITLE
Added dependency on the preupgrade-assistant-el6toel7 rpm

### DIFF
--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -11,6 +11,7 @@ Source0:        %{url}/archive/%{name}-%{version}.tar.gz
 Requires:       grubby
 Requires:       python-rhsm
 Requires:       preupgrade-assistant >= 2.2.0-1
+Requires:       preupgrade-assistant-el6toel7 >= 0.6.71
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1038299
 Requires:       yum >= 3.2.29-43


### PR DESCRIPTION
Upgrade from RHEL 6 system is impossible without modules of PA. The
requirements on PA is incomplete as required data and post-upgrade
scripts are provided by PA modules. PA itself provides only API
to get the data.

NOTE: required version of modules >= 0.6.71 is set because of the funcionality that it is currently tested for this version of modules