### PR TITLE
Decompress kernel modules

### DIFF
--- a/systemd/upgrade-init
+++ b/systemd/upgrade-init
@@ -51,6 +51,9 @@ do_reboot() {
     reboot --force
 }
 
+# Decompress kernel modules - applies to RHEL 7.4+
+find /lib/modules/$(uname -r) -name '*.ko.xz' | while read x; do xz -d $x; ln ${x%%.xz} $x; done
+
 # return the number of items given
 count() { echo $#; }
 


### PR DESCRIPTION
Since RHEL 7.4 the kernel modules are xz-compressed. The upgrade phase after reboot was failing because RHEL 6 modprobe is used for loading kernel modules and it doesn't support xz compression. To fix that all the kernel modules in the RHEL 7 initramfs are now decompressed before
any module is required.

Resolves: rhbz#[1486962](https://bugzilla.redhat.com/show_bug.cgi?id=1486962)