### PR TITLE
Always check if upgrading to the allowed RHEL version

### DIFF
--- a/man/redhat-upgrade-tool.8
+++ b/man/redhat-upgrade-tool.8
@@ -36,9 +36,9 @@ redhat\-upgrade\-tool [\fIOPTIONS\fR] \fBSOURCE\fR
 .sp
 \fBredhat\-upgrade\-tool\fR is the Red Hat Upgrade Tool\&.
 .sp
-The \fBredhat\-upgrade\-tool\fR client runs on the system to be upgraded\&. It determines what packages are needed for upgrade and gathers them from the source(s) given\&. It also fetches and sets up the boot images needed to run the upgrade and sets up the system to perform the upgrade at next boot\&.
+The \fBredhat\-upgrade\-tool\fR client runs on the source system\&. It determines what packages are needed for upgrade and gathers them from the given source(s)\&. It also fetches and sets up the boot images needed to run the upgrade and sets up the system to perform the upgrade at next boot\&.
 .sp
-The actual upgrade takes place when the system is rebooted, using the boot images set up by \fBredhat\-upgrade\-tool\fR\&. The upgrade initrd starts the existing system (mostly) as normal, lets it mount all the local filesystems, then starts the upgrade\&.
+The actual upgrade occurs when the system is rebooted, using the boot images set up by \fBredhat\-upgrade\-tool\fR\&. The upgrade initrd starts the source system as normal, lets it mount all the local filesystems, and then starts the upgrade\&.
 .sp
 When the upgrade finishes, it reboots the system into the newly\-upgraded OS\&.
 .SH "OPTIONS"
@@ -71,7 +71,7 @@ Automatically reboot to start the upgrade when ready\&.
 .RE
 .SS "SOURCE"
 .sp
-These options tell \fBredhat\-upgrade\-tool\fR where to look for the packages and boot images needed to run the upgrade\&. At least one of these options is required\&.
+These options provide \fBredhat\-upgrade\-tool\fR with the information where to look for the packages and boot images needed to run the upgrade\&. At least one of these options is required\&.
 .PP
 \fB\-\-device\fR [\fIDEV\fR]
 .RS 4
@@ -79,7 +79,7 @@ Device or mountpoint of mounted install media\&. If
 \fIDEV\fR
 is omitted,
 \fBredhat\-upgrade\-tool\fR
-will scan all currently\-mounted removable devices (USB disks, optical media, etc\&.)
+will scan all currently\-mounted removable devices (for example USB disks and optical media)\&.
 .RE
 .PP
 \fB\-\-iso\fR \fIISO\fR
@@ -91,7 +91,7 @@ Installation image file\&.
 .RS 4
 Online repos\&.
 \fIRELEASEVER\fR
-will be used to replace $releasever variable should it occur in any repo URL\&.
+will be used to replace $releasever variable if it occurs in some repo URL\&.
 .RE
 .sp
 Multiple sources may be used, if desired\&.
@@ -99,12 +99,12 @@ Multiple sources may be used, if desired\&.
 .PP
 \fB\-\-enablerepo\fR \fIREPOID\fR
 .RS 4
-Enable one or more repos (wildcards allowed)\&.
+Enable one or more repos (wildcards are allowed)\&.
 .RE
 .PP
 \fB\-\-disablerepo\fR \fIREPOID\fR
 .RS 4
-Disable one or more repos (wildcards allowed)\&.
+Disable one or more repos (wildcards are allowed)\&.
 .RE
 .PP
 \fB\-\-addrepo\fR \fIREPOID=[@]URL\fR
@@ -120,7 +120,7 @@ to indicate that the URL is a mirrorlist\&.
 Get upgrader boot images from the repo named
 \fIREPOID\fR\&. The repo must contain a valid
 \fI\&.treeinfo\fR
-file which points to the location of usable
+file, which points to the location of usable
 \fIkernel\fR
 and
 \fIupgrade\fR
@@ -130,7 +130,7 @@ images\&.
 .PP
 \fB\-\-resetbootloader\fR
 .RS 4
-Remove any modifications made to bootloader configuration\&.
+Remove any modifications made to the bootloader configuration\&.
 .RE
 .PP
 \fB\-\-clean\fR

--- a/man/redhat-upgrade-tool.8
+++ b/man/redhat-upgrade-tool.8
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: redhat-upgrade-tool
 .\"    Author: [see the "AUTHORS" section]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 11/08/2013
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 11/08/2017
 .\"    Manual: redhat-upgrade-tool User Manual
 .\"    Source: redhat-upgrade-tool
 .\"  Language: English
 .\"
-.TH "REDHAT\-UPGRADE\-TOOL" "8" "11/08/2013" "redhat\-upgrade\-tool" "redhat\-upgrade\-tool User Manual"
+.TH "REDHAT\-UPGRADE\-TOO" "8" "11/08/2017" "redhat\-upgrade\-tool" "redhat\-upgrade\-tool User Man"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -28,13 +28,13 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-redhat\-upgrade\-tool \- Red Hat Upgrade tool
+redhat-upgrade-tool \- Red Hat Upgrade tool
 .SH "SYNOPSIS"
 .sp
 redhat\-upgrade\-tool [\fIOPTIONS\fR] \fBSOURCE\fR
 .SH "DESCRIPTION"
 .sp
-\fBredhat\-upgrade\-tool\fR is the Red Hat Upgrade tool\&.
+\fBredhat\-upgrade\-tool\fR is the Red Hat Upgrade Tool\&.
 .sp
 The \fBredhat\-upgrade\-tool\fR client runs on the system to be upgraded\&. It determines what packages are needed for upgrade and gathers them from the source(s) given\&. It also fetches and sets up the boot images needed to run the upgrade and sets up the system to perform the upgrade at next boot\&.
 .sp
@@ -87,11 +87,11 @@ will scan all currently\-mounted removable devices (USB disks, optical media, et
 Installation image file\&.
 .RE
 .PP
-\fB\-\-network\fR \fIVERSION\fR
+\fB\-\-network\fR \fIRELEASEVER\fR
 .RS 4
-Online repos matching
-\fIVERSION\fR
-(a number or "rawhide")
+Online repos\&.
+\fIRELEASEVER\fR
+will be used to replace $releasever variable should it occur in any repo URL\&.
 .RE
 .sp
 Multiple sources may be used, if desired\&.
@@ -144,9 +144,9 @@ Clean up everything written by
 .sp
 Upgrade to RHEL 7\&.0 by downloading all needed packages and data from the specified repository\&.
 .sp
-\fBredhat\-upgrade\-tool \-\-device \-\-network 7\&.0\fR
+\fBredhat\-upgrade\-tool \-\-device\fR
 .sp
-Upgrade to RHEL 7\&.0 using install media mounted somewhere on the system, fetching updates from the network if needed\&.
+Upgrade the system by using installation media mounted on the system, fetching updates from the network if needed\&.
 .SH "EXIT STATUS"
 .PP
 0

--- a/man/redhat-upgrade-tool.8.asciidoc
+++ b/man/redhat-upgrade-tool.8.asciidoc
@@ -1,5 +1,5 @@
 redhat-upgrade-tool(8)
-========
+======================
 :man source:  redhat-upgrade-tool
 :man manual:  redhat-upgrade-tool User Manual
 
@@ -63,8 +63,9 @@ etc.)
 *--iso* 'ISO'::
 Installation image file.
 
-*--network* 'VERSION'::
-Online repos matching 'VERSION' (a number or "rawhide")
+*--network* 'RELEASEVER'::
+Online repos. 'RELEASEVER' will be used to replace $releasever variable should
+it occur in any repo URL.
 
 Multiple sources may be used, if desired.
 
@@ -105,9 +106,9 @@ EXAMPLES
 Upgrade to RHEL 7.0 by downloading all needed packages and data from the
 specified repository.
 
-*redhat-upgrade-tool --device --network 7.0*
+*redhat-upgrade-tool --device*
 
-Upgrade to RHEL 7.0 using install media mounted somewhere on the system,
+Upgrade the system by using installation media mounted on the system,
 fetching updates from the network if needed.
 
 EXIT STATUS

--- a/man/redhat-upgrade-tool.8.asciidoc
+++ b/man/redhat-upgrade-tool.8.asciidoc
@@ -16,14 +16,14 @@ DESCRIPTION
 -----------
 *redhat-upgrade-tool* is the Red Hat Upgrade Tool.
 
-The *redhat-upgrade-tool* client runs on the system to be upgraded. It determines what
-packages are needed for upgrade and gathers them from the source(s) given.
+The *redhat-upgrade-tool* client runs on the source system. It determines what
+packages are needed for upgrade and gathers them from the given source(s).
 It also fetches and sets up the boot images needed to run the upgrade and
 sets up the system to perform the upgrade at next boot.
 
-The actual upgrade takes place when the system is rebooted, using the boot
-images set up by *redhat-upgrade-tool*. The upgrade initrd starts the existing system
-(mostly) as normal, lets it mount all the local filesystems, then starts the
+The actual upgrade occurs when the system is rebooted, using the boot
+images set up by *redhat-upgrade-tool*. The upgrade initrd starts the source
+system as normal, lets it mount all the local filesystems, and then starts the
 upgrade.
 
 When the upgrade finishes, it reboots the system into the newly-upgraded OS.
@@ -52,20 +52,21 @@ Automatically reboot to start the upgrade when ready.
 SOURCE
 ~~~~~~
 
-These options tell *redhat-upgrade-tool* where to look for the packages and boot images
-needed to run the upgrade. At least one of these options is required.
+These options provide *redhat-upgrade-tool* with the information where to look
+for the packages and boot images needed to run the upgrade. At least one of
+these options is required.
 
 *--device* ['DEV']::
-Device or mountpoint of mounted install media. If 'DEV' is omitted, *redhat-upgrade-tool*
-will scan all currently-mounted removable devices (USB disks, optical media,
-etc.)
+Device or mountpoint of mounted install media. If 'DEV' is omitted,
+*redhat-upgrade-tool* will scan all currently-mounted removable devices
+(for example USB disks and optical media).
 
 *--iso* 'ISO'::
 Installation image file.
 
 *--network* 'RELEASEVER'::
-Online repos. 'RELEASEVER' will be used to replace $releasever variable should
-it occur in any repo URL.
+Online repos. 'RELEASEVER' will be used to replace $releasever variable if it
+occurs in some repo URL.
 
 Multiple sources may be used, if desired.
 
@@ -74,10 +75,10 @@ Additional options for *--network*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 *--enablerepo* 'REPOID'::
-Enable one or more repos (wildcards allowed).
+Enable one or more repos (wildcards are allowed).
 
 *--disablerepo* 'REPOID'::
-Disable one or more repos (wildcards allowed).
+Disable one or more repos (wildcards are allowed).
 
 *--addrepo* 'REPOID=[@]URL'::
 Add the repo at 'URL'. Prefix URL with '@' to indicate that the URL is a
@@ -85,7 +86,7 @@ mirrorlist.
 
 *--instrepo* 'REPOID'::
 Get upgrader boot images from the repo named 'REPOID'. The repo must contain a
-valid '.treeinfo' file which points to the location of usable 'kernel' and
+valid '.treeinfo' file, which points to the location of usable 'kernel' and
 'upgrade' images.
 
 
@@ -93,7 +94,7 @@ Cleanup commands
 ~~~~~~~~~~~~~~~~
 
 *--resetbootloader*::
-Remove any modifications made to bootloader configuration.
+Remove any modifications made to the bootloader configuration.
 
 *--clean*::
 Clean up everything written by *redhat-upgrade-tool*.

--- a/redhat-upgrade-tool.py
+++ b/redhat-upgrade-tool.py
@@ -117,7 +117,7 @@ def get_preupgrade_result_name():
                         settings.xml_result_name)
 
 
-def check_preupg_target_system_version():
+def check_preupg_target_system_version(treeinfo):
     if not os.path.exists(release_version_file):
         print _("First, run the Preupgrade Assistant to analyze the system.")
         raise SystemExit(1)
@@ -129,14 +129,15 @@ def check_preupg_target_system_version():
                 " Assistant:\n %s") % (release_version_file, e)
         raise SystemExit(1)
     try:
-        rel = release[1].strip()
+        preupg_supported_sysver = release[1].strip()
     except KeyError:
         print _("Error: The %s file provided by the Preupgrade Assistant has"
                 " incorrect content.") % release_version_file
         raise SystemExit(1)
-    if rel != args.network:
+    installation_media_sysver = treeinfo.get('general', 'version')
+    if preupg_supported_sysver != installation_media_sysver:
         print _("The installed version of Preupgrade Assistant allows upgrade"
-                " only to the system version %s." % args.network)
+                " only to the system version %s." % preupg_supported_sysver)
         raise SystemExit(1)
 
 
@@ -164,8 +165,8 @@ def main(args):
                          disable_plugins=args.disable_plugins,
                          noverifyssl=args.noverifyssl)
 
-    if not args.force and args.network:
-        check_preupg_target_system_version()
+    if not args.force:
+        check_preupg_target_system_version(f.treeinfo)
 
     if is_major_version_upgrade(f.treeinfo):
         major_upgrade = True

--- a/redhat-upgrade-tool.py
+++ b/redhat-upgrade-tool.py
@@ -49,6 +49,8 @@ from preupg import settings
 
 import logging
 log = logging.getLogger("redhat-upgrade-tool")
+
+
 def message(m):
     print m
     log.info(m)
@@ -75,6 +77,7 @@ def setup_downloader(version, instrepo=None, cacheonly=False, repos=[],
         log.info("disabled repos: " + " ".join(disabled_repos))
     return f
 
+
 def download_packages(f):
     updates = f.build_update_transaction(callback=output.DepsolveCallback(f))
     # check for empty upgrade transaction
@@ -95,6 +98,7 @@ def download_packages(f):
 
     return updates
 
+
 def transaction_test(pkgs):
     print _("testing upgrade transaction")
     pkgfiles = set(po.localPkg() for po in pkgs)
@@ -103,14 +107,17 @@ def transaction_test(pkgs):
     rv = fu.test_transaction(callback=output.TransactionCallback(numpkgs=len(pkgfiles)))
     return (probs, rv)
 
+
 def reboot():
     call(['reboot'])
+
 
 def get_preupgrade_result_name():
     return os.path.join(settings.assessment_results_dir,
                         settings.xml_result_name)
 
-def check_release_version_file():
+
+def check_preupg_target_system_version():
     if not os.path.exists(release_version_file):
         print _("First, run the Preupgrade Assistant to analyze the system.")
         raise SystemExit(1)
@@ -157,98 +164,20 @@ def main(args):
                          disable_plugins=args.disable_plugins,
                          noverifyssl=args.noverifyssl)
 
-    # Compare the first part of the version number in the treeinfo with the
-    # first part of the version number of the system to determine if this is a
-    # major version upgrade
     if not args.force and args.network:
-        check_release_version_file()
+        check_preupg_target_system_version()
 
-    if f.treeinfo.get('general', 'version').split('.')[0] != \
-            platform.linux_distribution()[1].split('.')[0]:
-
+    if is_major_version_upgrade(f.treeinfo):
         major_upgrade = True
-
-        # Check if preupgrade-assistant has been run
-        if args.force:
-            log.info("Skipping examining the Preupgrade Assistant results.")
+        if not args.force:
+            check_preupg_risks()
         else:
-            # Run preupg --riskcheck
-            returncode = XccdfHelper.check_inplace_risk(get_preupgrade_result_name(), 0)
-            if int(returncode) == 0:
-                print _("The Preupgrade Assistant hasn't found any risks.\n"
-                        "Upgrade will continue.")
-            elif int(returncode) == 1:
-                print _("The Preupgrade Assistant has found upgrade risks.\n"
-                        " You can run 'preupg --riskcheck --verbose' to view"
-                        " these risks.\nAddressing high risk issues is"
-                        " mandatory before continuing with the upgrade.\n"
-                        "Ignoring these risks may result in a broken and/or"
-                        " unsupported upgrade.\nPlease backup your data.\n\n"
-                        "List of issues:")
+            log.info("Skipping examining the Preupgrade Assistant results.")
 
-                XccdfHelper.check_inplace_risk(get_preupgrade_result_name(), verbose=2)
-
-                # Python 2.6 raises EOFError if raw_input receives a SIGWINCH.
-                # Try to tell the difference between that and a real EOF.
-
-                global sigwinch
-                sigwinch = False
-                def handle_sigwinch(signum, frame):
-                    global sigwinch
-                    sigwinch = True
-                orig_handler = signal.signal(signal.SIGWINCH, handle_sigwinch)
-
-                while True:
-                    try:
-                        sigwinch = False
-                        answer = raw_input(_("Continue with the upgrade [Y/N]? "))
-                        break
-                    except EOFError:
-                        if sigwinch:
-                            # Not a real EOF, try again
-                            print
-                            continue
-                        else:
-                            # Real EOF, exit
-                            answer = ''
-                            break
-                signal.signal(signal.SIGWINCH, orig_handler)
-
-                # TRANSLATORS: y for yes
-                if answer.lower() != _('y'):
-                    raise SystemExit(1)
-            elif int(returncode) == 2:
-                print _("The Preupgrade Assistant has found EXTREME upgrade"
-                        " risks.\nRun preupg --riskcheck --verbose to view\n"
-                        " these risks.\nContinuing with this upgrade is not\n"
-                        " recommended - the system will be unsupported\n"
-                        " and most likely broken after the upgrade.")
-                raise SystemExit(1)
-            else:
-                print _("The Preupgrade Assistant has not been run.\n"
-                        "To upgrade the system, run preupg first.")
-                raise SystemExit(1)
-
-    # Check that we are upgrading to the same variant
     if not args.force:
-        distro = platform.linux_distribution()[0]
-        if not distro.startswith("Red Hat Enterprise Linux "):
-            print _("Invalid distribution: %s") % distro
-            raise SystemExit(1)
-
-        from_variant = distro[len('Red Hat Enterprise Linux '):]
-        try:
-            to_variant = f.treeinfo.get('general', 'variant')
-        except NoOptionError:
-            print _("Upgrade repository is not a Red Hat Enterprise Linux repository")
-            raise SystemExit(1)
-
-        if from_variant != to_variant:
-            print _("Upgrade requested from Red Hat Enterprise Linux %s to %s") % (from_variant, to_variant)
-            print _("Upgrades between Red Hat Enterprise Linux variants is not supported.")
-            raise SystemExit(1)
+        check_same_variant_upgrade(f.treeinfo)
     else:
-        log.info("Skipping variant check")
+        log.info("Skipping system variant check.")
 
     if args.nogpgcheck:
         f._override_sigchecks = True
@@ -316,7 +245,6 @@ def main(args):
         # Run a test transaction
         probs, rv = transaction_test(pkgs)
 
-
     # And prepare for upgrade
     # TODO: use polkit to get root privs for these things
     print _("setting up system for upgrade")
@@ -329,7 +257,7 @@ def main(args):
     # Save the repo configuration
     f.save_repo_configs()
 
-    #dump all configuration to upgrade.conf, other tools need to know
+    # Dump all configuration to upgrade.conf, other tools need to know
     #TODO:some items are structured, would be nice to unpack them
     with Config(upgradeconf) as conf:
         argsdict = args.__dict__
@@ -344,7 +272,6 @@ def main(args):
     # before the postupgrade scripts are run.
     mkdir_p('/root/preupgrade')
     shutil.copyfile(upgradeconf, '/root/preupgrade/upgrade.conf')
-
 
     # Run the preuprade scripts if present
     if os.path.isdir(preupgrade_script_path):
@@ -430,6 +357,93 @@ def main(args):
             for line in s.format_details():
                 print "    "+line
         print _("Continue with the upgrade at your own risk.")
+
+
+def is_major_version_upgrade(treeinfo):
+    """Compare the first part of the version number in the treeinfo with the
+    first part of the version number of the system to determine if this is a
+    major version upgrade.
+    """
+    return treeinfo.get('general', 'version').split('.')[0] != \
+        platform.linux_distribution()[1].split('.')[0]
+
+
+def check_preupg_risks():
+    returncode = XccdfHelper.check_inplace_risk(get_preupgrade_result_name(), 0)
+    if int(returncode) == 0:
+        print _("The Preupgrade Assistant hasn't found any risks.\n"
+                "Upgrade will continue.")
+    elif int(returncode) == 1:
+        print _("The Preupgrade Assistant has found upgrade risks.\n"
+                " You can run 'preupg --riskcheck --verbose' to view"
+                " these risks.\nAddressing high risk issues is"
+                " mandatory before continuing with the upgrade.\n"
+                "Ignoring these risks may result in a broken and/or"
+                " unsupported upgrade.\nPlease backup your data.\n\n"
+                "List of issues:")
+
+        XccdfHelper.check_inplace_risk(get_preupgrade_result_name(), verbose=2)
+
+        # Python 2.6 raises EOFError if raw_input receives a SIGWINCH.
+        # Try to tell the difference between that and a real EOF.
+
+        global sigwinch
+        sigwinch = False
+        def handle_sigwinch(signum, frame):
+            global sigwinch
+            sigwinch = True
+        orig_handler = signal.signal(signal.SIGWINCH, handle_sigwinch)
+
+        while True:
+            try:
+                sigwinch = False
+                answer = raw_input(_("Continue with the upgrade [Y/N]? "))
+                break
+            except EOFError:
+                if sigwinch:
+                    # Not a real EOF, try again
+                    print
+                    continue
+                else:
+                    # Real EOF, exit
+                    answer = ''
+                    break
+        signal.signal(signal.SIGWINCH, orig_handler)
+
+        # TRANSLATORS: y for yes
+        if answer.lower() != _('y'):
+            raise SystemExit(1)
+    elif int(returncode) == 2:
+        print _("The Preupgrade Assistant has found EXTREME upgrade"
+                " risks.\nRun preupg --riskcheck --verbose to view\n"
+                " these risks.\nContinuing with this upgrade is not\n"
+                " recommended - the system will be unsupported\n"
+                " and most likely broken after the upgrade.")
+        raise SystemExit(1)
+    else:
+        print _("The Preupgrade Assistant has not been run.\n"
+                "To upgrade the system, run preupg first.")
+        raise SystemExit(1)
+
+
+def check_same_variant_upgrade(treeinfo):
+    distro = platform.linux_distribution()[0]
+    if not distro.startswith("Red Hat Enterprise Linux "):
+        print _("Invalid distribution: %s") % distro
+        raise SystemExit(1)
+
+    from_variant = distro[len('Red Hat Enterprise Linux '):]
+    try:
+        to_variant = treeinfo.get('general', 'variant')
+    except NoOptionError:
+        print _("Upgrade repository is not a Red Hat Enterprise Linux repository")
+        raise SystemExit(1)
+
+    if from_variant != to_variant:
+        print _("Upgrade requested from Red Hat Enterprise Linux %s to %s") % (from_variant, to_variant)
+        print _("Upgrades between Red Hat Enterprise Linux variants is not supported.")
+        raise SystemExit(1)
+
 
 if __name__ == '__main__':
     args = parse_args()

--- a/redhat_upgrade_tool/commandline.py
+++ b/redhat_upgrade_tool/commandline.py
@@ -85,9 +85,9 @@ def parse_args(gui=False):
         help=_('device or mountpoint. default: check mounted devices'))
     req.add_option('--iso', type="isofile",
         help=_('installation image file'))
-    # Translators: This is for '--network [VERSION]' in --help output
-    req.add_option('--network', metavar=_('VERSION'), type="VERSION",
-        help=_('online repos matching VERSION (a number or "rawhide")'))
+    req.add_option('--network', metavar=_('RELEASEVER'), type="RELEASEVER",
+        help=_('online repos. \'RELEASEVER\' will be used to replace'
+               ' $releasever variable should it occur in any repo URL.'))
 
 
     # === options for --network ===
@@ -212,7 +212,7 @@ def gpgkeyfile(option, opt, value):
         raise optparse.OptionValueError(_("File is not a GPG key"))
     return 'file://' + os.path.abspath(arg)
 
-def VERSION(option, opt, value):
+def RELEASEVER(option, opt, value):
     if value.lower() == 'rawhide':
         return 'rawhide'
 
@@ -226,7 +226,7 @@ def VERSION(option, opt, value):
         if value[0] == '-':
             msg = _("%s option requires an argument") % opt
         else:
-            msg = _("Invalid value for version")
+            msg = _("Invalid value for --network option")
         raise optparse.OptionValueError(msg)
 
     if value >= version:
@@ -236,12 +236,13 @@ def VERSION(option, opt, value):
         raise optparse.OptionValueError(msg)
 
 class Option(optparse.Option):
-    TYPES = optparse.Option.TYPES + ("device_or_mnt", "isofile", "VERSION", "gpgkeyfile")
+    TYPES = optparse.Option.TYPES + \
+        ("device_or_mnt", "isofile", "RELEASEVER", "gpgkeyfile")
     TYPE_CHECKER = copy(optparse.Option.TYPE_CHECKER)
 
     TYPE_CHECKER["device_or_mnt"] = device_or_mnt
     TYPE_CHECKER["isofile"] = isofile
-    TYPE_CHECKER["VERSION"] = VERSION
+    TYPE_CHECKER["RELEASEVER"] = RELEASEVER
     TYPE_CHECKER["gpgkeyfile"] = gpgkeyfile
 
 def do_cleanup(args):

--- a/redhat_upgrade_tool/commandline.py
+++ b/redhat_upgrade_tool/commandline.py
@@ -283,8 +283,10 @@ def device_setup(args):
         try:
             args.device = media.loopmount(args.iso)
         except media.CalledProcessError as e:
-            log.info("mount failure: %s", e.output)
-            message('--iso: '+_('Unable to open %s') % args.iso)
+            msg = _("mount failure: %s\n"
+                    "--iso: Unable to open %s") % (e.output, args.iso)
+            print msg
+            log.info(msg)
             raise SystemExit(2)
         else:
             args.repos.append(('add', 'upgradeiso=file://%s' % args.device.mnt))


### PR DESCRIPTION
Running the Preupgrade Assistant is a mandatory prerequisite before upgrading the system with the Red Hat Upgrade Tool. The Preupgrade Assistant performs a set of checks and many of them are relevant for one specific upgrade "path" only, e.g. for upgrades of RHEL 6.9 to RHEL 7.4. Because the Red Hat Upgrade Tool works with the information provided by the Preupgrade Assistant, the Red Hat Upgrade Tool needs to allow upgrading the system **only** to such a RHEL version for which the Preupgrade Assistant analysis has been designed for.

There was a limited[1] check just for _network_ as a source; for _iso_ or _device_ sources there wasn't any check at all. Now, the RHEL version specified in the _.treeinfo_ file of the installation media (be it network, iso or device) need to match the RHEL version specified by the Preupgrade Assistant.

This PR also includes:
- rewording some of the user-facing messages
- code cleanup: spaghetti into smaller functions

[1] The limited check was comparing the RHEL version passed through the `--network` option against the Preupgrade Assistant-generated data.

Resolves: https://github.com/upgrades-migrations/redhat-upgrade-tool/issues/30