### PR TITLE
Revert "Added dependency on preupgrade-assistant-el6toel7 rpm"

### DIFF
--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -11,7 +11,6 @@ Source0:        %{url}/archive/%{name}-%{version}.tar.gz
 Requires:       grubby
 Requires:       python-rhsm
 Requires:       preupgrade-assistant >= 2.2.0-1
-Requires:       preupgrade-assistant-el6toel7 >= 0.6.71
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1038299
 Requires:       yum >= 3.2.29-43


### PR DESCRIPTION
We found this dependency making troubles. The dependency is not correct as the _preupgrade-assistant-el6toel7_ package is not required by the r-u-t, it actually needs the result (data) of the system assessment. The solution of this would be making of versioning of the assessment itself (see issue #31).