### PR TITLE
Add option to disable /boot size check

### DIFF
--- a/man/redhat-upgrade-tool.8
+++ b/man/redhat-upgrade-tool.8
@@ -64,6 +64,11 @@ Print lots of debugging info\&.
 Continue even if the Preupgrade Assistant risk check fails\&. Use it at your own risk\&.
 .RE
 .PP
+\fB\-\-no\-space\-check\fR
+.RS 4
+Disable check of free space in /boot\&. By default the required minimum before reboot is 50 MiB\&. Use it at your own risk\&.
+.RE
+.PP
 \fB\-\-debuglog\fR \fIDEBUGLOG\fR
 .RS 4
 Write debugging output to the given file\&. Defaults to

--- a/man/redhat-upgrade-tool.8.asciidoc
+++ b/man/redhat-upgrade-tool.8.asciidoc
@@ -45,6 +45,10 @@ Print lots of debugging info.
 *--force*::
 Continue even if the Preupgrade Assistant risk check fails. Use it at your own risk.
 
+*--no-space-check*::
+Disable check of free space in /boot. By default the required minimum before
+reboot is 50 MiB. Use it at your own risk.
+
 *--debuglog* 'DEBUGLOG'::
 Write debugging output to the given file. Defaults to '/var/log/redhat-upgrade-tool.log'.
 

--- a/redhat-upgrade-tool.py
+++ b/redhat-upgrade-tool.py
@@ -304,7 +304,7 @@ def main(args):
     # installation during the upgrade.
     statvfs = os.statvfs("/boot")
     avail_bytes = statvfs.f_frsize * statvfs.f_bavail
-    if avail_bytes < MIN_AVAIL_BYTES_FOR_BOOT:
+    if not args.no_space_check and avail_bytes < MIN_AVAIL_BYTES_FOR_BOOT:
         reset_boot()
         additional_mib_needed = \
             (MIN_AVAIL_BYTES_FOR_BOOT - avail_bytes) / 2**20

--- a/redhat_upgrade_tool/commandline.py
+++ b/redhat_upgrade_tool/commandline.py
@@ -24,6 +24,7 @@ from . import media
 from . import packagedir
 from .sysprep import reset_boot, remove_boot, remove_cache, misc_cleanup
 from . import _
+from . import MIN_AVAIL_BYTES_FOR_BOOT
 
 import logging
 log = logging.getLogger(__package__)
@@ -45,6 +46,11 @@ def parse_args(gui=False):
     p.add_option('-f', '--force', action='store_true', default=False,
             help=_('continue even if the Preupgrade Assistant risk check'
                    'fails. Use it at your own risk.'))
+
+    p.add_option('--no-space-check', action='store_true', default=False,
+                 help=_('disable check of free space in /boot. By default the'
+                        ' required minimum before reboot is 50 MiB. Use it at'
+                        ' your own risk.'))
     p.add_option('--cleanup-post', action='store_true', default=False,
             help=_('cleanup old package after the upgrade'))
 


### PR DESCRIPTION
- Some users have very limited disk space available, especially on
the /boot partition, and the minimum of 50 MiB we require to
have before reboot can be too much for them.
- The minimum of 50 MiB we require includes some cushioning for the
future as the size of kernel is expected to grow. The real minimum
needed is currently ~42 MiB.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1518317