### PR TITLE
Modify the SPEC file & stuff around

### DIFF
--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -1,6 +1,5 @@
 %global version_boom 0.8
 %global boom_dir boom-%{version_boom}
-%global name_subpkg modules
 
 Name:           redhat-upgrade-tool
 Version:        0.7.52
@@ -83,11 +82,6 @@ install -m 644 examples/boom.conf ${RPM_BUILD_ROOT}/boot/boom
 # Automatically enable legacy bootloader support for RHEL6 builds
 sed -i 's/enable = False/enable = True/' ${RPM_BUILD_ROOT}/boot/boom/boom.conf
 
-# probably all man here we can skip, but keeping for possible later remove
-mkdir -p ${RPM_BUILD_ROOT}/%{_mandir}/man5
-mkdir -p ${RPM_BUILD_ROOT}/%{_mandir}/man8
-install -m 644 man/man5/boom.5 ${RPM_BUILD_ROOT}/%{_mandir}/man5
-install -m 644 man/man8/boom.8 ${RPM_BUILD_ROOT}/%{_mandir}/man8
 popd
 
 # Move the boom utility under libexec as it is not supposed to be used by
@@ -107,7 +101,6 @@ fi
 # boom doc files
 %license %{boom_dir}/COPYING
 %doc %{boom_dir}/README.md
-%doc %{_mandir}/man*/boom.*
 %if 0%{?sphinx_docs}
 %doc doc/html/
 %endif # if sphinx_docs

--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -90,8 +90,9 @@ install -m 644 man/man5/boom.5 ${RPM_BUILD_ROOT}/%{_mandir}/man5
 install -m 644 man/man8/boom.8 ${RPM_BUILD_ROOT}/%{_mandir}/man8
 popd
 
-# cleaning ...
-#rm -f ${RPM_BUILD_ROOT}/%{_bindir}/boom
+# Move the boom utility under libexec as it is not supposed to be used by
+# users directly
+mv ${RPM_BUILD_ROOT}/%{_bindir}/boom ${RPM_BUILD_ROOT}/%{_libexecdir}/boom
 
 %post
 if [ ! -e /var/lib/dbus/machine-id ]; then
@@ -137,7 +138,7 @@ fi
 
 # boom
 %{python_sitelib}/boom*
-%{_bindir}/boom
+%{_libexecdir}/boom
 /etc/grub.d/42_boom
 %config(noreplace) /etc/default/boom
 %config(noreplace) /boot/boom/boom.conf

--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -13,15 +13,20 @@ URL:            https://github.com/upgrades-migrations/redhat-upgrade-tool
 Source0:        %{url}/archive/%{name}-%{version}.tar.gz
 Source1:        boom-%{version_boom}.tar.gz
 
+Requires:       dbus
 Requires:       grubby
 Requires:       python-rhsm
+Requires:       python-argparse
 Requires:       preupgrade-assistant >= 2.2.0-1
-Requires:       %{name}-%{name_subpkg}
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1038299
 Requires:       yum >= 3.2.29-43
 
 BuildRequires:  python-libs
+BuildRequires:  python2-devel
+BuildRequires:  python-sphinx
+BuildRequires:  python-setuptools
+
 BuildArch:      noarch
 
 # GET THEE BEHIND ME, SATAN
@@ -30,18 +35,6 @@ Obsoletes:      preupgrade
 %description
 redhat-upgrade-tool is the Red Hat Enterprise Linux Upgrade tool.
 
-%package %{name_subpkg}
-Summary: modules for redhat-upgrade-tool to support rollbacks
-Buildarch: noarch
-BuildRequires: python2-devel
-BuildRequires: python-sphinx
-BuildRequires: python-setuptools
-
-Requires: python-argparse
-Requires: dbus
-
-%description %{name_subpkg}
-%{summary}
 
 
 %prep
@@ -100,14 +93,25 @@ popd
 # cleaning ...
 #rm -f ${RPM_BUILD_ROOT}/%{_bindir}/boom
 
-%post %{name_subpkg}
+%post
 if [ ! -e /var/lib/dbus/machine-id ]; then
     dbus-uuidgen > /var/lib/dbus/machine-id
 fi
 
 
 %files
+%{!?_licensedir:%global license %%doc}
 %doc README.asciidoc COPYING
+
+# boom doc files
+%license %{boom_dir}/COPYING
+%doc %{boom_dir}/README.md
+%doc %{_mandir}/man*/boom.*
+%if 0%{?sphinx_docs}
+%doc doc/html/
+%endif # if sphinx_docs
+%doc %{boom_dir}/examples/*
+
 # systemd stuff
 %if 0%{?_unitdir:1}
 %{_unitdir}/system-upgrade.target
@@ -131,15 +135,7 @@ fi
 # empty updates dir
 %dir /etc/redhat-upgrade-tool/update.img.d
 
-%files %{name_subpkg}
-%{!?_licensedir:%global license %%doc}
-%license %{boom_dir}/COPYING
-%doc %{boom_dir}/README.md
-%doc %{_mandir}/man*/boom.*
-%if 0%{?sphinx_docs}
-%doc doc/html/
-%endif # if sphinx_docs
-%doc %{boom_dir}/examples/*
+# boom
 %{python_sitelib}/boom*
 %{_bindir}/boom
 /etc/grub.d/42_boom

--- a/redhat_upgrade_tool/rollback/bootloader.py
+++ b/redhat_upgrade_tool/rollback/bootloader.py
@@ -27,10 +27,11 @@ _SNAP_BOOT_FILES = [
     "config-{0}",
 ]
 
+_BOOM_UTIL_PATH = "/usr/libexec/boom"
 
 def create_boot_entry(title, os_profile, root_lv):
     cmd = [
-        "boom", "create",
+        _BOOM_UTIL_PATH, "create",
         "--profile", os_profile,
         "--title", title,
         "--root-lv", root_lv
@@ -44,7 +45,7 @@ def create_boot_entry(title, os_profile, root_lv):
 
 def boom_cleanup(os_profile):
     cmd = [
-        "boom", "delete",
+        _BOOM_UTIL_PATH, "delete",
         "--profile", os_profile
     ]
     try:


### PR DESCRIPTION
This PR resolves issues and unwanted stuff around packaging on RHEL 6 connected to rollback functionality:

1. *Merge redhat-upgrade-tool-modules into the main RPM*
It doesn't make sense to keep the subpackage as functionality is broken without that and has to be always installed.

2. Move the boom utility under libexec (instead of /usr/bin/boom)

3. Do not install man pages of Boom.
    Users are not supposed to use Boom directly on RHEL 6 so it doesn't make sense to install manual pages.