### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -2,7 +2,7 @@
 %global boom_dir boom-%{version_boom}
 
 Name:           redhat-upgrade-tool
-Version:        0.7.52
+Version:        0.8.0
 Release:        1%{?dist}
 Summary:        The Red Hat Enterprise Linux Upgrade tool
 Epoch:          1
@@ -140,6 +140,10 @@ fi
 
 
 %changelog
+* Thu Sep 06 2018 Petr Stodulka <pstodulk@redhat.com> - 1:0.8.0-1
+- Add the rollback capability
+  Resolves: rhbz#1625999
+
 * Tue Jun 12 2018 Michal Bocek <mbocek@redhat.com> - 1:0.7.52-1
 - Add option to disable /boot size check
   Resolves: rhbz#1518317

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ class BuildScripts(build_scripts):
                 os.rename(outfile, newfile)
 
 setup(name="redhat-upgrade-tool",
-      version="0.7.52",
+      version="0.8.0",
       description="Red Hat Upgrade",
       long_description="",
       author="Will Woods",


### PR DESCRIPTION
As the rollbacks are the most probably the largest change we did in
the last years in this tool and probably there will not be another
so big change in future, we decided to bump the minor version as
this release contains a lot of changes - even when original
fuctionality should be untouched by these changes in case user will
not use the rollback capability for upgrades.

Praise the sun!