### PR TITLE
Rollbacks: enable rollbacks only on the x86_64 arch

### DIFF
--- a/redhat-upgrade-tool.py
+++ b/redhat-upgrade-tool.py
@@ -176,6 +176,9 @@ def main(args):
         raise SystemExit(1)
 
     if args.snapshot_root_lv:
+        if platform.machine() != "x86_64":
+            print _("Error: Rollbacks are possible only on the x86_64 architecture.")
+            raise SystemExit(1)
         create_cleanup_script()
 
     if args.system_restore:


### PR DESCRIPTION
Just raise an error and stop upgrades when machine has different arch from `x86_64` and when rollbacks are used.